### PR TITLE
fix: 修复TailedSquadCombat只能绘制两个点的问题，以及AssaultDirection与1.0版本中“突击方向”不对应的问题

### DIFF
--- a/packages/ol-plot/src/geometry/Arrow/AssaultDirection.ts
+++ b/packages/ol-plot/src/geometry/Arrow/AssaultDirection.ts
@@ -9,9 +9,9 @@ import FineArrow from './FineArrow';
 class AssaultDirection extends FineArrow {
   constructor(coordinates, points, params) {
     super(coordinates, points, params);
-    this.tailWidthFactor = 0.05;
-    this.neckWidthFactor = 0.1;
-    this.headWidthFactor = 0.15;
+    this.tailWidthFactor = 0.2;
+    this.neckWidthFactor = 0.25;
+    this.headWidthFactor = 0.3;
     this.type = PlotTypes.ASSAULT_DIRECTION;
     this.headAngle = Math.PI / 4;
     this.neckAngle = Math.PI * 0.17741;

--- a/packages/ol-plot/src/geometry/Arrow/TailedSquadCombat.ts
+++ b/packages/ol-plot/src/geometry/Arrow/TailedSquadCombat.ts
@@ -20,7 +20,6 @@ class TailedSquadCombat extends AttackArrow {
     this.tailWidthFactor = 0.1;
     this.swallowTailFactor = 1;
     this.swallowTailPnt = null;
-    this.fixPointCount = 2;
     this.set('params', params);
     if (points && points.length > 0) {
       this.setPoints(points);


### PR DESCRIPTION
Fixes #48 

### 修复内容

1. 在起初的1.0版本中，TailedSquadCombat，即分队战斗行动（尾），可以绘制多个点，自从2.0版本后，只能绘制两个点，退化成普通的箭头。
2. 在起初的1.0版本中，AssaultDirection，即突击方向，是经典的、较为认可的图形，自动2.0版本后，由于系数改了，导致形状变了，与“AssaultDirection（突击方向）”这个名称对应不上。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the appearance of the Assault Direction arrow, resulting in a wider tail, neck, and head.
- **Refactor**
  - Internal property cleanup for the Tailed Squad Combat arrow; no impact on visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->